### PR TITLE
added null check when invalidating the dismiss timer

### DIFF
--- a/TTGSnackbar/TTGSnackbar.cs
+++ b/TTGSnackbar/TTGSnackbar.cs
@@ -496,8 +496,11 @@ namespace SnackBarTTG.Source
 		*/
 		private void invalidDismissTimer()
 		{
-			dismissTimer.Invalidate();
-			dismissTimer = null;
+			if (dismissTimer != null)
+			{
+				dismissTimer.Invalidate();
+				dismissTimer = null;
+			}
 		}
 
 		/**


### PR DESCRIPTION
Pressing the ActionButton sometimes causes a NullPointerException. The reason is the invalidation of the dismiss timer. If the action button is pressed at the same time the timer runs out, the invalidation of the timer is executed twice. 

I have added a null check.