### PR TITLE
fixed action and separator visibility

### DIFF
--- a/TTGSnackbar/TTGSnackbar.cs
+++ b/TTGSnackbar/TTGSnackbar.cs
@@ -311,9 +311,12 @@ namespace TTGSnackBar
             // Create dismiss timer
             dismissTimer = NSTimer.CreateScheduledTimer(Duration, (t) => Dismiss());
 
-            // Show or hide action button
-
+            // Show or hide Icon
             IconImageView.Hidden = (Icon == null);
+
+            // Show or hide action button
+            ActionButton.Hidden = string.IsNullOrEmpty(ActionText) || ActionBlock == null;
+            SecondActionButton.Hidden = string.IsNullOrEmpty(SecondActionText) || SecondActionBlock == null;
 
             SeperateView.Hidden = ActionButton.Hidden;
 


### PR DESCRIPTION
Added two lines of code to hide the ActionButtons and separator if not applicable. This code was based upon the original project at https://github.com/zekunyan/TTGSnackbar and aligns the two project a bit more.

## UPDATE:
I just noticed that another PR ([this one](https://github.com/MarcBruins/TTGSnackbar-Xamarin-iOS/pull/21)) already solved the problem. However I think my simple addition is still good for code robustness. If somebody in the future forgets to set the ActionButton one way or another, this will make sure that the code is still consistent.

fixes #19 